### PR TITLE
Remove copied copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-Copyright (c) 2009 Jacob Kaplan-Moss - initial codebase (< v2.1)
-Copyright (c) 2011 Rackspace - OpenStack extensions (>= v2.1)
-Copyright (c) 2011 Nebula, Inc - Keystone refactor (>= v2.7)
-All rights reserved.
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
Copyright was being assigned in the LICENSE file based on the keystone
code this was obviously copied from. It is not relevant to this project.