### PR TITLE
Remove references to gate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
 import setuptools
 
 # In python < 2.7.4, a lazy loading of package `pbr` will break

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 # The order of packages is significant, because pip processes them in the order
-# of appearance. Changing the order has an impact on the overall integration
-# process, which may cause wedges in the gate later.
+# of appearance.
 
 hacking<0.11,>=0.10.0
 flake8-docstrings==0.2.1.post1


### PR DESCRIPTION
We aren't submitting this project to openstack infrastructure so there
is no gate or global requirements. Remove references to them.